### PR TITLE
Fixed issue where game could not find component keys in ServerPlayerEntity. 

### DIFF
--- a/src/main/java/net/anvian/record_days_survived/RecordDaysSurvivedMod.java
+++ b/src/main/java/net/anvian/record_days_survived/RecordDaysSurvivedMod.java
@@ -95,4 +95,5 @@ public class RecordDaysSurvivedMod implements ModInitializer, EntityComponentIni
         registry.registerForPlayers(RECORD_DAY, RecordDayComponent::new, RespawnCopyStrategy.ALWAYS_COPY);
         registry.registerForPlayers(TICKS_PASSED, TicksPassedComponent::new, RespawnCopyStrategy.NEVER_COPY);
     }
+
 }

--- a/src/main/java/net/anvian/record_days_survived/RecordDaysSurvivedMod.java
+++ b/src/main/java/net/anvian/record_days_survived/RecordDaysSurvivedMod.java
@@ -95,5 +95,4 @@ public class RecordDaysSurvivedMod implements ModInitializer, EntityComponentIni
         registry.registerForPlayers(RECORD_DAY, RecordDayComponent::new, RespawnCopyStrategy.ALWAYS_COPY);
         registry.registerForPlayers(TICKS_PASSED, TicksPassedComponent::new, RespawnCopyStrategy.NEVER_COPY);
     }
-
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,7 +19,7 @@
 		"main": [
 			"net.anvian.record_days_survived.RecordDaysSurvivedMod"
 		],
-		"cardinal_components-entity": [
+		"cardinal-components-entity": [
 			"net.anvian.record_days_survived.RecordDaysSurvivedMod"
 		]
 	},


### PR DESCRIPTION
In the 1.20.6 version of this mod, the player would receive an error when starting up a world that stated that the game could not find the components registered by this mod in `ServerPlayerEntity`. This issue was caused by a typo in `fabric.mod.json`, which I have fixed. 